### PR TITLE
Add steps to run WSO2 Update

### DIFF
--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -55,3 +55,42 @@ can quickly set up and try out a basic flow.
     |WSO2 API Manager|`<APIM_HOME>`|
     |WSO2 Open Banking Identity Server Accelerator|`<OB_IS_ACCELERATOR_HOME>`|
     |WSO2 Open Banking API Manager Accelerator |`<OB_APIM_ACCELERATOR_HOME>`|
+
+## Getting WSO2 Updates
+
+The WSO2 Update tool delivers hotfixes and updates seamlessly on top of products as WSO2 Updates. They include 
+improvements that are released by WSO2. You need to update the base products and accelerators using the relevant script.
+
+1. Go to `<PRODUCT_HOME>/bin` and run the WSO2 Update tool:
+
+    - Repeat this step for the WSO2 Identity Server, API Manager, and Stream Integrator products.
+    
+        ```bash tab='On Linux'
+        wso2update_linux 
+        ```
+        
+        ```bash tab='On Mac'
+        wso2update_darwin
+        ```
+        
+        ```bash tab='On Windows'
+        wso2update_windows.exe
+        ```
+
+2. Go to `<ACCELERATOR_HOME>/bin` and run the WSO2 Update tool:
+
+    - Repeat this step for the WSO2 Open Banking Identity Server, API Manager, and Business Intelligence accelerators.
+
+        ```bash tab='On Linux'
+        wso2update_linux 
+        ```
+        
+        ```bash tab='On Mac'
+        wso2update_darwin
+        ```
+        
+        ```bash tab='On Windows'
+        wso2update_windows.exe
+        ```
+   
+For more information, see the [WSO2 Updates documentation](https://updates.docs.wso2.com/en/latest/updates/overview/).

--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -12,26 +12,8 @@ can quickly set up and try out a basic flow.
         export JAVA_HOME="<JDK_LOCATION>"
         export PATH=$PATH:$JAVA_HOME/bin
         ```
-    2. Download and extract the following base products:
-        1. WSO2 Identity Server (IS) 5.11.0 
-        2. WSO2 API Manager (APIM) 4.0.0
-        3. WSO2 Streaming Integrator (SI) 4.0.0
-    3. To configure the Identity Server with the API Manager, download WSO2 IS Connector from
-     [here](https://apim.docs.wso2.com/en/4.0.0/assets/attachments/administer/wso2is-extensions-1.2.10.zip).
-    4. If you have an active WSO2 Open Banking subscription, contact us via [WSO2 Online Support System](https://support.wso2.com/) 
-       to download Open Banking Accelerator 3.0.0.
-       
-        !!! note
-            If you don't have a WSO2 Open Banking subscription, [contact us](https://wso2.com/solutions/financial/open-banking/#contact) 
-            for more information.
-              
-    5. WSO2 Open Banking Accelerator contains the following accelerators.
-   
-         - wso2-ob-is-accelerator-3.0.0
-         - wso2-ob-apim-accelerator-3.0.0
-         - wso2-ob-bi-accelerator-3.0.0
-            
-    6. Setup a database server using any of the following:
+    
+    2. Setup a database server using any of the following:
          - Mysql 5.7 or above
          - Microsoft SQL Server 2017
          - Oracle 19c
@@ -39,12 +21,37 @@ can quickly set up and try out a basic flow.
          
         !!!note
             We do not recommend configuring H2 database in the production environment.
+    
+## Installing base products
 
-- This document uses the following placeholders to refer to the following products:
+1. Download and extract the following base products:
+    1. WSO2 Identity Server (IS) 5.11.0 
+    2. WSO2 API Manager (APIM) 4.0.0
+    3. WSO2 Streaming Integrator (SI) 4.0.0
+    
+2. To configure the Identity Server with the API Manager, download WSO2 IS Connector from 
+[here](https://apim.docs.wso2.com/en/4.0.0/assets/attachments/administer/wso2is-extensions-1.2.10.zip).
+
+## Installing WSO2 Open Banking Accelerator
+
+1. If you have an active WSO2 Open Banking subscription, contact us via 
+[WSO2 Online Support System](https://support.wso2.com/) to download Open Banking Accelerator 3.0.0.
+       
+    !!! note
+        If you don't have a WSO2 Open Banking subscription, [contact us](https://wso2.com/solutions/financial/open-banking/#contact) 
+        for more information.
+              
+2. WSO2 Open Banking Accelerator contains the following accelerators.
+   
+    - wso2-ob-is-accelerator-3.0.0
+    - wso2-ob-apim-accelerator-3.0.0
+    - wso2-ob-bi-accelerator-3.0.0
+            
+3. This document uses the following placeholders to refer to the following products:
         
-| Product | Placeholder |
-|---------|---------    |
-|WSO2 Identity Server|`<IS_HOME>`|
-|WSO2 API Manager|`<APIM_HOME>`|
-|WSO2 Open Banking Identity Server Accelerator|`<OB_IS_ACCELERATOR_HOME>`|
-|WSO2 Open Banking API Manager Accelerator |`<OB_APIM_ACCELERATOR_HOME>`|
+    | Product | Placeholder |
+    |---------|---------    |
+    |WSO2 Identity Server|`<IS_HOME>`|
+    |WSO2 API Manager|`<APIM_HOME>`|
+    |WSO2 Open Banking Identity Server Accelerator|`<OB_IS_ACCELERATOR_HOME>`|
+    |WSO2 Open Banking API Manager Accelerator |`<OB_APIM_ACCELERATOR_HOME>`|

--- a/en/docs/install-and-setup/setting-up-servers.md
+++ b/en/docs/install-and-setup/setting-up-servers.md
@@ -53,36 +53,41 @@ homes.
 ## Getting WSO2 Updates
 
 The WSO2 Update tool delivers hotfixes and updates seamlessly on top of products as WSO2 Updates. They include 
-improvements that are released by WSO2. For more information, see the 
-[WSO2 Updates documentation](https://updates.docs.wso2.com/en/latest/updates/overview/).
+improvements that are released by WSO2. You need to update the base products and accelerators using the relevant script.
 
-1. Go to `<OB_APIM_ACCELERATOR_HOME>/bin` and run the WSO2 Update tool:
- 
-    ```bash tab='On Linux'
-    wso2update_linux 
-    ```
-    
-    ```bash tab='On Mac'
-    wso2update_darwin
-    ```
-    
-    ```bash tab='On Windows'
-    wso2update_windows.exe
-    ```
+1. Go to `<PRODUCT_HOME>/bin` and run the WSO2 Update tool:
 
-2. Go to `<OB_IS_ACCELERATOR_HOME>/bin` and run the WSO2 Update tool:
+    - Repeat this step for the WSO2 Identity Server, API Manager, and Stream Integrator products.
+    
+        ```bash tab='On Linux'
+        wso2update_linux 
+        ```
+        
+        ```bash tab='On Mac'
+        wso2update_darwin
+        ```
+        
+        ```bash tab='On Windows'
+        wso2update_windows.exe
+        ```
 
-    ```bash tab='On Linux'
-    wso2update_linux 
-    ```
-    
-    ```bash tab='On Mac'
-    wso2update_darwin
-    ```
-    
-    ```bash tab='On Windows'
-    wso2update_windows.exe
-    ```
+2. Go to `<ACCELERATOR_HOME>/bin` and run the WSO2 Update tool:
+
+    - Repeat this step for the WSO2 Open Banking Identity Server, API Manager, and Business Intelligence accelerators.
+
+        ```bash tab='On Linux'
+        wso2update_linux 
+        ```
+        
+        ```bash tab='On Mac'
+        wso2update_darwin
+        ```
+        
+        ```bash tab='On Windows'
+        wso2update_windows.exe
+        ```
+   
+For more information, see the [WSO2 Updates documentation](https://updates.docs.wso2.com/en/latest/updates/overview/).
 
 ## Setting up Accelerator
 


### PR DESCRIPTION
## Purpose
- This PR is to add steps to run the WSO2 Update tool in QSG.
- Mentions that we need to first update base products and then accelerators. 
- Restructured the QSG/get-started page with sub-topics for easy navigation. (similar to Install and Set up section).