### PR TITLE
Add U2 issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/u2_changes.md
+++ b/.github/ISSUE_TEMPLATE/u2_changes.md
@@ -1,0 +1,44 @@
+---
+name: U2 Changes
+about: Document changes released via U2
+title: '[U2] <title>'
+---
+
+  ### Affected OB version:
+  <!-- Mention which version(s) are affected by this change. -->
+
+  ### Affected OB specifications:
+  <!-- Mention the supported OB specification(s) affected by this change. -->
+
+  ### Existing pages to be updated:
+  <!-- Mention the existing page(s) that need to be updated-->
+
+  ### Description (Optional):
+  <!-- If this is a new feature, add a brief description of the feature including the following points:
+    - Business use case
+    - Optional or mandatory feature
+    - Technical specification
+  -->
+
+  ### Instructions:
+  <!-- Add the instructions here and include the following:
+    - What needs to be done added/changed/removed
+    - Which component(IS/APIM/OBBI) and which file(s) need to be updated
+    - Mention the new configs/changes
+    - Does this change require restarting the servers?
+  -->
+
+  ### Release date:
+  <!-- Mention the release date of U2-->
+
+  ### References:
+  <!-- Link all relevant support PRs or issues -->
+  
+  ### Labels:
+  <!-- Directly add labels if you have edit rights or list them
+  - Version of the solution (ex. 130, 150, 200 etc)
+  - Affected specification (ex. UK, Australia, Berlin etc)
+  - Priority (low, high, highest)
+  - For errors/gaps, use the label “Type/bug” 
+  - For improvements, use the label “Type/enhancement” 
+  -->


### PR DESCRIPTION
## Purpose
This PR is to add a new issue template for U2 doc issues. 

This contains the same fields discussed in [Issue Template for WUM/Updates](https://docs.google.com/document/d/1SmudesilB_7sJEFDgdk2i0cxbUVm0H3OqRBQn8Xla2A/edit)