### PR TITLE
Update versions page

### DIFF
--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -150,8 +150,8 @@ request.onload = function() {
                   .setAttribute('href', docSetUrl + data.all[data.current].notes);
         
           // Pre-release version update
-          document.getElementById('pre-release-version-documentation-link')
-              .setAttribute('href', docSetUrl + 'next/');
+//          document.getElementById('pre-release-version-documentation-link')
+//              .setAttribute('href', docSetUrl + 'next/');
       }
       
   } else {

--- a/en/docs/assets/versions.json
+++ b/en/docs/assets/versions.json
@@ -9,7 +9,7 @@
   "all": {
     "3.0.0": {
       "doc": "3.0.0",
-      "notes": "3.0.0/about/about-this-release"
+      "notes": "latest/get-started/about-this-release/"
     },
     "2.0.0": {
       "doc": "https://docs.wso2.com/display/OB200/",

--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -40,31 +40,6 @@ This is the current stable version of the project.
 
 ---
 
-### Pre-release versions
-These are the latest changes that are yet to be released.
-
-<table>
-    <tbody>
-        <tr>
-            <th>next</th>
-            <td>
-                <a id="pre-release-version-documentation-link">Documentation</a>
-            </td>
-            <td>
-                <a href="https://github.com/wso2/docs-open-banking/tree/master" target="_blank">
-                    <div class="md-source-code-icon">
-                        <svg viewBox="0 0 24 24" width="24" height="24">
-                          <use xlink:href="#__github" width="24" height="24"></use>
-                        </svg>
-                    </div> Source Code
-                </a>
-            </td>
-        </tr>
-    </tbody>
-</table>
-
----
-
 ### Past Versions
 
 <table>


### PR DESCRIPTION
This PR is to update the https://ob.docs.wso2.com/en/versions/ page and remove the "pre-release" version.