### PR TITLE
[OB3] Mention the security vulnerability specified in CVE-2019-13990 for quartz.properties

### DIFF
--- a/en/docs/install-and-setup/configuring-identity-server-for-ob.md
+++ b/en/docs/install-and-setup/configuring-identity-server-for-ob.md
@@ -148,7 +148,7 @@ database server, and the JDBC driver.
     
     ??? info "Click here to see the configurations for periodical consent expiration in a clustered setup."
        
-        - :exclamation: It's important to note that, `quartz.properties` is not recommended to use for initializing custom job data from an XML file, As there's a security vulnerability specified in CVE-2019-13990.
+        -  **Due to a security vulnerability specified in CVE-2019-13990, `quartz.properties` is not recommended for initializing custom job data from an XML file.**
         - Add the `quartz.properties` file to `<IS_HOME>/repository/conf` and enable clustering by configuring the
           datasources according to the
           [Quartz Configuration Reference](http://www.quartz-scheduler.org/documentation/quartz-2.1.7/configuration/).

--- a/en/docs/install-and-setup/configuring-identity-server-for-ob.md
+++ b/en/docs/install-and-setup/configuring-identity-server-for-ob.md
@@ -148,7 +148,8 @@ database server, and the JDBC driver.
     
     ??? info "Click here to see the configurations for periodical consent expiration in a clustered setup."
        
-        - Add the `quartz.properties` file to `<IS_HOME>/repository/conf` and enable clustering by configuring the 
+        - :exclamation: It's important to note that, `quartz.properties` is not recomoded to use for initializing custom job data from xml file, As there's a security vulnarability specified in CVE-2019-13990.
+        - Add the `quartz.properties` file to `<IS_HOME>/repository/conf` and enable clustering by configuring the
           datasources according to the
           [Quartz Configuration Reference](http://www.quartz-scheduler.org/documentation/quartz-2.1.7/configuration/).
         - Create a new database and use the database scripts available 

--- a/en/docs/install-and-setup/configuring-identity-server-for-ob.md
+++ b/en/docs/install-and-setup/configuring-identity-server-for-ob.md
@@ -148,7 +148,7 @@ database server, and the JDBC driver.
     
     ??? info "Click here to see the configurations for periodical consent expiration in a clustered setup."
        
-        - :exclamation: It's important to note that, `quartz.properties` is not recomoded to use for initializing custom job data from xml file, As there's a security vulnarability specified in CVE-2019-13990.
+        - :exclamation: It's important to note that, `quartz.properties` is not recommended to use for initializing custom job data from an XML file, As there's a security vulnerability specified in CVE-2019-13990.
         - Add the `quartz.properties` file to `<IS_HOME>/repository/conf` and enable clustering by configuring the
           datasources according to the
           [Quartz Configuration Reference](http://www.quartz-scheduler.org/documentation/quartz-2.1.7/configuration/).


### PR DESCRIPTION
## Purpose

>This PR is to mention the security vulnerability specified in CVE-2019-13990 for **org.quartz-scheduler : quartz : 2.1.1**

- **initDocumentParser** in xml/XMLSchedulingDataProcessor.java in Quartz Scheduler 2.1.1 allows XXE attacks via a job description.

- We do not use the vulnerable class or method in our code base. 

- However there's a possibility of configuring a XML job description via exposed `quartz.properties` file. Thus adding this documentation to mitigate the security vulnerability.