### PR TITLE
[OB3] Doc changes related to quartz version upgrade to 2.3.2

### DIFF
--- a/en/docs/assets/attachments/quartz.properties
+++ b/en/docs/assets/attachments/quartz.properties
@@ -1,4 +1,5 @@
-org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPoolorg.quartz.threadPool.threadCount = 25
+org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
+org.quartz.threadPool.threadCount = 25
         
 # Datasource for JDBCJobStore
 org.quartz.dataSource.myDS.driver = com.mysql.jdbc.Driver

--- a/en/docs/install-and-setup/configuring-identity-server-for-ob.md
+++ b/en/docs/install-and-setup/configuring-identity-server-for-ob.md
@@ -148,16 +148,15 @@ database server, and the JDBC driver.
     
     ??? info "Click here to see the configurations for periodical consent expiration in a clustered setup."
        
-        - :exclamation: It's important to note that, `quartz.properties` is not recommended to use for initializing custom job data from an XML file, As there's a security vulnerability specified in CVE-2019-13990.
         - Add the `quartz.properties` file to `<IS_HOME>/repository/conf` and enable clustering by configuring the
           datasources according to the
           [Quartz Configuration Reference](http://www.quartz-scheduler.org/documentation/quartz-2.1.7/configuration/).
         - Create a new database and use the database scripts available 
-          [here](https://svn.terracotta.org/svn/quartz/tags/quartz-2.1.7/docs/dbTables/)
+          [here](https://github.com/quartz-scheduler/quartz/tree/quartz-2.3.x/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore)
           to create the quartz cluster tables.
         - Add following jars to the `<IS_HOME>/repository/component/lib` directory.
             - [mchange-commons-java-0.2.20.jar](https://repo1.maven.org/maven2/com/mchange/mchange-commons-java/0.2.20/mchange-commons-java-0.2.20.jar)
-            - [c3p0-0.9.2.1.jar](https://repo1.maven.org/maven2/com/mchange/c3p0/0.9.2.1/c3p0-0.9.2.1.jar)
+            - [c3p0-0.9.5.4.jar](https://repo1.maven.org/maven2/com/mchange/c3p0/0.9.5.4/c3p0-0.9.5.4.jar)
         - Copy the same `quartz.properties` file to each instance in the cluster and update the `instanceId`. 
         - Click [here](../assets/attachments/quartz.properties) to download a sample `quartz.properties` configuration file.
        


### PR DESCRIPTION
## Purpose

>This PR is to mention the Doc changes related to quartz version upgrade to 2.3.2

- Removed below quote as upgraded quartz jar does not have the security vulnerability.

`Due to a security vulnerability specified in CVE-2019-13990, **quartz.properties** is not recommended for initializing custom job data from an XML file.`

- Add dependency and DB changes for clustering setup