### PR TITLE
Replace Oracle JDK with OpenJDK

### DIFF
--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -6,7 +6,7 @@ This section guides you on how to set up the solution in a local environment. Fo
 can quickly set up and try out a basic flow.
 
 !!! tip "Prerequisites"
-    1. Download Oracle JDK 1.8 to the local environment.
+    1. Download OpenJDK 11 to the local environment.
         - In the environment variables, update the JAVA_HOME and PATH variables. For instance, you can do this on a Mac/Linux server by adding the following to the ~/.bashrc file:
         ```
         export JAVA_HOME="<JDK_LOCATION>"

--- a/en/docs/install-and-setup/prerequisites.md
+++ b/en/docs/install-and-setup/prerequisites.md
@@ -82,7 +82,7 @@ Listed below are the prerequisites for a successful deployment:
          <th>JDK Version</th>
          <td>
             <ul>
-               <li>Oracle JDK 11</li>
+               <li>OpenJDK 11</li>
             </ul>
          <td>  
       </tr>
@@ -116,10 +116,10 @@ WSO2 Open Banking Accelerator 3.0.0 is supported on the following platforms:
          <td>
             <ul>
                <li>
-                  Oracle JDK 11
+                  OpenJDK 11
                </li>
                <li>
-                  OpenJDK 11
+                  Oracle JDK 11
                </li>
             </ul>
          </td>


### PR DESCRIPTION
## Purpose
This PR is to replace Oracle JDK with OpenJDK in Quick Start Guide and Prerequisites pages in OB 3 Accelerator documentation.