### PR TITLE
Update jwks url for reg-aggregator

### DIFF
--- a/en/docs/toolkits/regulatory-aggregator/regulatory-aggregator-qsg.md
+++ b/en/docs/toolkits/regulatory-aggregator/regulatory-aggregator-qsg.md
@@ -194,8 +194,8 @@ This section explains how to set up the remaining WSO2 Identity Server and API M
     d. Update the following `[open_banking.dcr]` configurations:
 
       ``` toml
-      jwks_url_sandbox = "https://keystore.openbankingtest.org.uk/0015800001HQQrZAAX/u3ZWlf9Yt42dyZgIvzkvqb.jwks"
-      jwks_url_production = "https://keystore.openbankingtest.org.uk/0015800001HQQrZAAX/u3ZWlf9Yt42dyZgIvzkvqb.jwks"
+      jwks_url_sandbox = "https://keystore.openbankingtest.org.uk/0015800001HQQrZAAX/0015800001HQQrZAAX.jwks"
+      jwks_url_production = "https://keystore.openbankingtest.org.uk/0015800001HQQrZAAX/0015800001HQQrZAAX.jwks"
       applicationupdater = "com.wso2.openbanking.sample.aggregator.identity.AggregatorApplicationUpdaterImpl"
       ```
 


### PR DESCRIPTION
Update the JWKS url for regulator aggregator as the certs are expired. 

This PR will update the URL according to https://github.com/wso2/docs-open-banking/pull/650