### PR TITLE
Add issue template for GA release features

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,0 +1,51 @@
+---
+name: New Features released via a GA release
+about: Document new features released via a GA release
+title: '[GA] <title>'
+---
+
+  ### Affected OB specifications:
+  <!-- Mention the supported OB specification(s) affected by this change. -->
+
+  ### New pages to be added/ Existing pages to be updated:
+  <!-- Mention if a new page is required. 
+    - Suggestions to where to place this as a new page/section
+    - Mention if an existing page(s) needs to be updated.
+    - Mention if the new feature falls under an existing subtopic.
+  -->
+
+  ### Description:
+  <!-- 1. Feature intro (For Learn section) - For every new feature, add a brief description of the feature including the following points:
+    - Business use case (provide a summary of the business problem and solution)
+    - Whether optional or mandatory
+    - Technical specification (For example: API, Interface)
+    - High level architecture diagrams (If applicable)
+    - UML diagrams (If applicable)
+
+    - 2. Configurations - Include the following instructions here:
+    - Prerequisites (If applicable)/ Conditions - Setting up servers, Setting up DBs (DB creation details/ DB scripts/ location), Configuring IS, APIM, etc.
+    - Clearly mention the new configs/ default TOML values and applicable values
+
+    - 3. Try out flow
+    - How to set up the pack/ deploy APIs, etc
+    - Screenshots (If applicable)
+    - API request/ response payload
+
+    - 4. Does this feature provide an accelerator extension point? Yes/No
+    - If yes, please fill the Extension Issue Template (https://github.com/wso2/docs-open-banking/issues/new?assignees=&labels=&template=ob_extension.md&title=%5BOB3%5D%5BEXT%5D+%3Ctitle%3E) as well.
+  -->
+
+  ### References:
+  <!-- Link the following:
+  - All relevant support PRs or issues
+  - Feature document created by the developer
+  - Mail threads (if any)
+  - Articles released by the authority (if any)
+  -->
+
+  ### Labels:
+  <!-- Directly add labels if you have edit rights or list them
+  - Affected specification (accelerator, berlin-toolkit, cds-toolkit, uk-tooolkit)
+  - Use the label “Type/New Feature”
+  - Milestones 
+  -->

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -32,7 +32,7 @@ title: '[GA] <title>'
     - API request/ response payload
 
     - 4. Does this feature provide an accelerator extension point? Yes/No
-    - If yes, please fill the Extension Issue Template (https://github.com/wso2/docs-open-banking/issues/new?assignees=&labels=&template=ob_extension.md&title=%5BOB3%5D%5BEXT%5D+%3Ctitle%3E) as well.
+    - If yes, please fill the [Extension Issue Template](https://github.com/wso2/docs-open-banking/issues/new?assignees=&labels=&template=ob_extension.md&title=%5BOB3%5D%5BEXT%5D+%3Ctitle%3E) as well.
   -->
 
   ### References:


### PR DESCRIPTION
## Purpose
This issue is to add a new issue template for GA release features. 

This will fix https://github.com/wso2/docs-open-banking/issues/688.