### PR TITLE
Change CIBA Authenticator display name in Federated Authenticators

### DIFF
--- a/en/docs/learn/ciba-set-up-flow.md
+++ b/en/docs/learn/ciba-set-up-flow.md
@@ -215,7 +215,7 @@ configuration with the IP address of the Identity Server.
 1. Log in to the Identity Server Management Console at `https://<IS_HOST>:9446/carbon` as an admin user.
 2. Go to **Identity Providers > Add**.
 3. Register a new IDP for Push Authentication. Use the name **CIBA-Push-Auth**.
-4. Go to **Federated Authenticators > CIBA Push Authentication Configuration** and enable the Push Authenticator.
+4. Go to **Federated Authenticators > CIBA Authentication Configuration** and enable the Push Authenticator.
 5. IDP configurations:
      - Firebase Server Key: Create an [FCM project](https://fcm.googleapis.com/fcm/send) when setting up the mobile 
        application. Add the Server Key of that application here. You can obtain it from the 

--- a/en/docs/learn/ciba-set-up-flow.md
+++ b/en/docs/learn/ciba-set-up-flow.md
@@ -215,7 +215,7 @@ configuration with the IP address of the Identity Server.
 1. Log in to the Identity Server Management Console at `https://<IS_HOST>:9446/carbon` as an admin user.
 2. Go to **Identity Providers > Add**.
 3. Register a new IDP for Push Authentication. Use the name **CIBA-Push-Auth**.
-4. Go to **Federated Authenticators > CIBA Authentication Configuration** and enable the Push Authenticator.
+4. Go to **Federated Authenticators > CIBA Authenticator Configuration** and enable the Push Authenticator.
 5. IDP configurations:
      - Firebase Server Key: Create an [FCM project](https://fcm.googleapis.com/fcm/send) when setting up the mobile 
        application. Add the Server Key of that application here. You can obtain it from the 


### PR DESCRIPTION
Change authenticator name form "CIBA Push Authentication Configuration" to "CIBA Authentication Configuration", which is displayed in the carbon console UI.

<img width="1212" alt="Screenshot 2024-03-05 at 12 22 54" src="https://github.com/wso2/docs-open-banking/assets/25720507/ec996ec8-6f75-4a9d-922e-bda921069581">
