### PR TITLE
Add adaptive authentication note for docker JDK 17 deployment

### DIFF
--- a/en/docs/install-and-setup/deploy-with-docker.md
+++ b/en/docs/install-and-setup/deploy-with-docker.md
@@ -23,6 +23,15 @@ This page explains two methods of deploying the solution in Docker containers.
     have a WSO2 Open Banking subscription, [contact us](https://wso2.com/solutions/financial/open-banking/#contact)
     for more information.
 
+??? warning "If you are using a JDK 17 obiam docker image, adaptive authentication is disabled by default."
+
+    To create a Docker image with adaptive authentication enabled, add the following commands to your Dockerfile and run it against the base image. 
+
+    ```
+    RUN chmod +x ${WSO2_IAM_SERVER_HOME}/bin/adaptive.sh
+    RUN ${WSO2_IAM_SERVER_HOME}/bin/adaptive.sh
+    ```
+
   - If you are looking for a Quick Start Guide and deploy the solution, follow 
   [Deploy WSO2 Open Banking with Docker Compose](#deploy-wso2-open-banking-with-docker-compose).
 

--- a/en/docs/install-and-setup/deploy-with-docker.md
+++ b/en/docs/install-and-setup/deploy-with-docker.md
@@ -23,7 +23,7 @@ This page explains two methods of deploying the solution in Docker containers.
     have a WSO2 Open Banking subscription, [contact us](https://wso2.com/solutions/financial/open-banking/#contact)
     for more information.
 
-??? warning "If you are using a JDK 17 obiam docker image, adaptive authentication is disabled by default."
+??? warning "If you are using a JDK 17 obiam docker image (wso2is versions 6.0.0 and above), adaptive authentication is disabled by default."
 
     To create a Docker image with adaptive authentication enabled, add the following commands to your Dockerfile and run it against the base image. 
 
@@ -31,6 +31,8 @@ This page explains two methods of deploying the solution in Docker containers.
     RUN chmod +x ${WSO2_IAM_SERVER_HOME}/bin/adaptive.sh
     RUN ${WSO2_IAM_SERVER_HOME}/bin/adaptive.sh
     ```
+
+    See [Enable adaptive authentication](https://is.docs.wso2.com/en/6.1.0/deploy/enable-adaptive-authentication/) for more information.
 
   - If you are looking for a Quick Start Guide and deploy the solution, follow 
   [Deploy WSO2 Open Banking with Docker Compose](#deploy-wso2-open-banking-with-docker-compose).


### PR DESCRIPTION
## Purpose
> Adaptive auth is disabled by default in obiam jdk17 docker images. This doc PR is to note what should be done to enable it.
