### PR TITLE
Added the missing instructions when setting up the accelerators on windows.

### DIFF
--- a/en/docs/get-started/set-up-accelerators.md
+++ b/en/docs/get-started/set-up-accelerators.md
@@ -31,17 +31,50 @@ This section explains how to set up the solution with a MySQL 8.0 database serve
 4. Open the `<IS_HOME>/<OB_IS_ACCELERATOR_HOME>/repository/conf/configure.properties` file and repeat step 2 and 3.
      
 ### Step 3: Set up servers 
-1. Run the `merge.sh` script in `<APIM_HOME>/<OB_APIM_ACCELERATOR_HOME>/bin` and 
+1. Run the merge script in `<APIM_HOME>/<OB_APIM_ACCELERATOR_HOME>/bin` and 
 `<IS_HOME>/<OB_IS_ACCELERATOR_HOME>/bin` respectively:
-    ```
+    ```bash tab='On Linux'
     ./merge.sh
     ```
-
-2. Run the configure.sh files in `<APIM_HOME>/<OB_APIM_ACCELERATOR_HOME>/bin` and 
-`<IS_HOME>/<OB_IS_ACCELERATOR_HOME>/bin` respectively:
+    
+    ```bash tab='On Mac'
+    ./merge.sh
     ```
+    
+    ```bash tab='On Windows'
+    ./merge.ps1
+    ```
+
+2. Run the configure files in `<APIM_HOME>/<OB_APIM_ACCELERATOR_HOME>/bin` and 
+`<IS_HOME>/<OB_IS_ACCELERATOR_HOME>/bin` respectively:
+    ```bash tab='On Linux'
     ./configure.sh
     ```
+    
+    ```bash tab='On Mac'
+    ./configure.sh
+    ```
+    
+    ```powershell tab='On Windows'
+    ./configure.ps1
+    ```
+
+??? warning "If you are using windows platform..."
+    If you are using windows platform, since the merge.ps1 and configure.ps1 files are not digitally signed yet,
+    your powershell might prevent you from running them normally. In that case you may need to run these
+    scripts in a powershell instance where its execution policy is set to bypass mode.
+    
+    Use the following command to run these scripts in execution policy bypassed powershell environment.
+
+    ```
+    powershell -executionpolicy bypass .\merge.ps1
+    ```
+
+    ```
+    powershell -executionpolicy bypass .\configure.ps1
+    ```
+
+    IMPORTANT : Do not run any other unverified scripts using this way. This is a temporary solution. 
 
 3. If you are using **WSO2 Identity Server 6.0.0**,
 

--- a/en/docs/install-and-setup/setting-up-servers.md
+++ b/en/docs/install-and-setup/setting-up-servers.md
@@ -116,23 +116,52 @@ For more information, see the [WSO2 Updates documentation](https://updates.docs.
 1. To copy the accelerator files to the API Manager server, go to the `<APIM_HOME>/<OB_APIM_ACCELERATOR_HOME>/bin` 
 directory and run the `merge.sh` script as follows:
 
-    ``` shell 
+    ```bash tab='On Linux'
     ./merge.sh
+    ```
+    
+    ```bash tab='On Mac'
+    ./merge.sh
+    ```
+    
+    ```bash tab='On Windows'
+    ./merge.ps1
     ```
  
 2. To copy the accelerator files to the Identity Server, go to the `<IS_HOME>/<OB_IS_ACCELERATOR_HOME>/bin` directory 
-and run the `merge.sh` script as follows:
+and run the merge script as follows:
    
-    ``` shell 
+    ```bash tab='On Linux'
     ./merge.sh
+    ```
+    
+    ```bash tab='On Mac'
+    ./merge.sh
+    ```
+    
+    ```bash tab='On Windows'
+    ./merge.ps1
     ```
 
 3. To copy the accelerator files to the Streaming Integrator, go to the `<SI_HOME>/<OB_BI_ACCELERATOR_HOME>/bin` 
-directory and run the `merge.sh` script as follows:
+directory and run the merge script as follows:
 
     ``` shell 
     ./merge.sh
     ``` 
+
+??? warning "If you are using windows platform..."
+    If you are using windows platform, since the merge.ps1 file is not digitally signed yet,
+    your powershell might prevent you from running this script normally. In that case you
+    may need to run it in a powershell instance where its execution policy is set to bypass mode.
+    
+    Use the following command to run it in execution policy bypassed powershell environment.
+
+    ```
+    powershell -executionpolicy bypass .\merge.ps1
+    ```
+
+    IMPORTANT : Do not run any other unverified scripts using this way. This is a temporary solution. 
 
 4. Extract the `wso2is-extensions` zip file of the relevant API Manager version. 
 


### PR DESCRIPTION
## Purpose
Adding the missing instructions regarding setting up accelerators on windows platform. Resolving https://github.com/wso2/docs-open-banking/issues/893 issue.

## Documentation
https://ob.docs.wso2.com/en/latest/install-and-setup/setting-up-servers/#setting-up-accelerator
https://ob.docs.wso2.com/en/latest/get-started/set-up-accelerators/#step-3-set-up-servers

## Related PRs
https://github.com/wso2/financial-open-banking/pull/88