### PR TITLE
Fix typo in setup instructions for WSO2 API Manager

### DIFF
--- a/en/docs/install-and-setup/setting-up-databases.md
+++ b/en/docs/install-and-setup/setting-up-databases.md
@@ -213,7 +213,7 @@ database configurations.
     pool_options.defaultAutoCommit=true
     ```
 
-2. Add or update the default datasource configurations in `<APIM_HOME>/repository/conf/deployment.toml` with your database configurations. This step is required of youar setting up with WSO2 API Manager.
+2. Add or update the default datasource configurations in `<APIM_HOME>/repository/conf/deployment.toml` with your database configurations. This step is required of your setting up with WSO2 API Manager.
 
     - Given below is the relevant datasource configuration for each database:
    


### PR DESCRIPTION
This pull request corrects a minor typo in the database setup documentation for WSO2 API Manager.

- Documentation fix:
  * Corrected a typo in the instructions for updating datasource configurations in `setting-up-databases.md` ("youar" changed to "your").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typographical errors in database configuration documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->