### PR TITLE
Add UK JWS Header Processing Policy sections to MCR payments flow documentation

### DIFF
--- a/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow.md
+++ b/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow.md
@@ -154,6 +154,42 @@ The response contains a Consent ID. A sample response looks as follows:
 }
 ```
 
+#### With UK JWS Header Processing Policy
+
+Just like Step 2, if you have enabled the [UK JWS Header Processing Policy](../../learn/uk-jws-header-processing-policy.md), this request **must be signed** with a Detached JWS using your TPP Private Key.
+
+```
+curl -X POST \
+https://localhost:8243/open-banking/v3.1/pisp/payments \
+-H 'x-fapi-financial-id: open-bank' \
+-H 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json; charset=UTF-8' \
+-H 'x-idempotency-key: 249667' \
+-H 'x-jws-signature: <JWS_SIGNATURE>' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<REQUEST_PAYLOAD>'
+```
+
+- `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
+
+#### With UK JWS Header Processing Policy
+
+If you have enabled the [UK JWS Header Processing Policy](../../learn/uk-jws-header-processing-policy.md), the payload of this request must be digitally signed using your TPP Private Key. You must generate a Detached JWS (Header..Signature) and pass it in the `x-jws-signature` HTTP header. The payload used to generate the signature **must exactly match** the JSON body of your request (no extra spaces or newlines).
+
+```
+curl --location --request POST 'https://localhost:8243/open-banking/v3.1/pisp/payment-consents' \
+--header 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+--header 'x-fapi-financial-id: open-bank' \
+--header 'Content-Type: application/json' \
+--header 'x-idempotency-key: 709909' \
+--header 'x-jws-signature: <JWS_SIGNATURE>' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<REQUEST_PAYLOAD>'
+```
+
+- `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
+
 ### Step 3: Authorizing a consent
 
 The API consumer application redirects the bank customer to authenticate and approve/deny application-provided consents.

--- a/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow.md
+++ b/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow.md
@@ -156,25 +156,6 @@ The response contains a Consent ID. A sample response looks as follows:
 
 #### With UK JWS Header Processing Policy
 
-Just like Step 2, if you have enabled the [UK JWS Header Processing Policy](../../learn/uk-jws-header-processing-policy.md), this request **must be signed** with a Detached JWS using your TPP Private Key.
-
-```
-curl -X POST \
-https://localhost:8243/open-banking/v3.1/pisp/payments \
--H 'x-fapi-financial-id: open-bank' \
--H 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
--H 'Accept: application/json' \
--H 'Content-Type: application/json; charset=UTF-8' \
--H 'x-idempotency-key: 249667' \
--H 'x-jws-signature: <JWS_SIGNATURE>' \
---cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
---data '<REQUEST_PAYLOAD>'
-```
-
-- `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
-
-#### With UK JWS Header Processing Policy
-
 If you have enabled the [UK JWS Header Processing Policy](../../learn/uk-jws-header-processing-policy.md), the payload of this request must be digitally signed using your TPP Private Key. You must generate a Detached JWS (Header..Signature) and pass it in the `x-jws-signature` HTTP header. The payload used to generate the signature **must exactly match** the JSON body of your request (no extra spaces or newlines).
 
 ```
@@ -401,3 +382,22 @@ The TPP must ensure that the Initiation and Risk sections of payment match the c
     }
 }
 ```
+
+#### With UK JWS Header Processing Policy
+
+Just like Step 2, if you have enabled the [UK JWS Header Processing Policy](../../learn/uk-jws-header-processing-policy.md), this request **must be signed** with a Detached JWS using your TPP Private Key.
+
+```
+curl -X POST \
+https://localhost:8243/open-banking/v3.1/pisp/payments \
+-H 'x-fapi-financial-id: open-bank' \
+-H 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/json; charset=UTF-8' \
+-H 'x-idempotency-key: 249667' \
+-H 'x-jws-signature: <JWS_SIGNATURE>' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<REQUEST_PAYLOAD>'
+```
+
+- `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.


### PR DESCRIPTION
This PR updates the MCR payments flow documentation to include optional guidance for deployments using UK JWS Header Processing Policy.

## Changes
-Added a separate With UK JWS Header Processing Policy section after Step 2 response.
-Added a separate With UK JWS Header Processing Policy section after Step 5 response.
-Included sample curl commands with x-jws-signature: <JWS_SIGNATURE> placeholder.
-Added brief header explanation for x-jws-signature.
-Kept the normal flow unchanged and clearly separated from policy-specific instructions.

## File Updated
-try-out-payments-flow.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for UK JWS Header Processing Policy implementation, including detailed instructions for signing payment-consent initiation and payment submission requests using Detached JWS with TPP private key credentials and `x-jws-signature` headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->