### PR TITLE
Update APIM lib path in policy docs

### DIFF
--- a/en/docs/learn/jwe-payload-processing-policy.md
+++ b/en/docs/learn/jwe-payload-processing-policy.md
@@ -40,7 +40,7 @@ If you want to build the Financial Services APIM Mediation Policies from the sou
 2. Extract the zip `fs-apim-mediation-artifacts-1.0.0.zip` and you will notice the following folder structure.
     - `Policy .j2 files` - The mediation policy files which need to upload in API Publisher UI and engage to APIs. Below mediation policies are available in this repository.
     - `Custom sequences` - Synapse based custom sequence files which need to copy in to `<APIM_HOME>/repository/deployment/server/synapse-configs/default/sequences` folder.
-    - `lib` - This folder contains the jars need to copy in to `<APIM_Home>/repository/lib` folder. It contains jars of the class mediator implementations refer from the policies and custom synapse handler implementations.
+    - `lib` - This folder contains the jars need to copy in to `<APIM_Home>/repository/components/lib` folder. It contains jars of the class mediator implementations refer from the policies and custom synapse handler implementations.
         
 3. Add the following configuration to `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder.
 

--- a/en/docs/learn/jwe-payload-processing-policy.md
+++ b/en/docs/learn/jwe-payload-processing-policy.md
@@ -42,12 +42,24 @@ If you want to build the Financial Services APIM Mediation Policies from the sou
     - `Custom sequences` - Synapse based custom sequence files which need to copy in to `<APIM_HOME>/repository/deployment/server/synapse-configs/default/sequences` folder.
     - `lib` - This folder contains the jars need to copy in to `<APIM_Home>/repository/components/lib` folder. It contains jars of the class mediator implementations refer from the policies and custom synapse handler implementations.
         
-3. Add the following configuration to `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder.
+3. Add the following configurations to the `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder.
 
     ``` toml
     [synapse_handlers.jws_response_signature_handler]
     enabled = true
     class = "org.wso2.financial.services.apim.mediation.policies.jws.header.processing.handler.JwsResponseHeaderHandler"
+    ```
+
+    Add the following custom message builder and formatter to handle the `application/jose+jwe` content type:
+
+    ``` toml
+    [[custom_message_builders]]
+    content_type = "application/jose+jwe"
+    class = "org.apache.axis2.format.PlainTextBuilder"
+
+    [[custom_message_formatters]]
+    content_type = "application/jose+jwe"
+    class = "org.apache.axis2.format.PlainTextFormatter"
     ```
 
 4. Restart the API Manager Server.

--- a/en/docs/learn/uk-jws-header-processing-policy.md
+++ b/en/docs/learn/uk-jws-header-processing-policy.md
@@ -32,7 +32,7 @@ If you want to build the Financial Services APIM Mediation Policies from the sou
 2. Extract the zip 'fs-apim-mediation-artifacts-1.0.0.zip' and you will notice the following folder structure.
     - Policy .j2 files - The mediation policy files which need to upload in API Publisher UI and engage to APIs. Below mediation policies are available in this repository.
     - Custom sequences- Synapse based custom sequence files which need to copy in to `<APIM_HOME>/repository/deployment/server/synapse-configs/default/sequences` folder.
-    - lib - This folder contains the jars need to copy in to `<APIM_Home>/repository/lib` folder. It contains jars of the class mediator implementations refer from the policies and custom synapse handler implementations.
+    - lib - This folder contains the jars need to copy in to `<APIM_Home>/repository/components/lib` folder. It contains jars of the class mediator implementations refer from the policies and custom synapse handler implementations.
         
 3. Add the following configuration to `deployment.toml` file inside the `<APIM_Home>/repository/conf` folder.
 

--- a/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-accounts-flow-dcr.md
+++ b/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-accounts-flow-dcr.md
@@ -116,6 +116,36 @@ The response contains a Consent ID. A sample response looks as follows:
 }
 ```
 
+#### With JWE Payload Processing Policy
+
+If you have enabled the [JWE Payload Processing Policy](../../learn/jwe-payload-processing-policy.md), the request payload must be encrypted as a JWE (JSON Web Encryption) compact serialization using the server's public key. You must also add the following custom message builder and formatter configurations to the `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder:
+
+``` toml
+[[custom_message_builders]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextBuilder"
+
+[[custom_message_formatters]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextFormatter"
+```
+
+After adding the above configuration, restart the API Manager server.
+
+The consent initiation request with JWE encryption looks as follows:
+
+```
+curl --location --request POST 'https://localhost:8243/open-banking/v3.1/aisp/account-access-consents' \
+--header 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+--header 'x-fapi-financial-id: open-bank' \
+--header 'Content-Type: application/jose+jwe' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<JWE_ENCRYPTED_PAYLOAD>'
+```
+
+- `Content-Type`: Must be set to `application/jose+jwe` to trigger the JWE decryption mediator.
+- `<JWE_ENCRYPTED_PAYLOAD>`: The request body encrypted as a JWE compact serialization (5 base64url-encoded parts separated by dots). Encrypt the JSON payload using the server's public certificate (e.g., `wso2carbon` alias from the server keystore) with the algorithm and encryption method configured in the policy (e.g., `RSA-OAEP-256` and `A256GCM`).
+
 ### Step 3: Authorizing a consent
 
 The API consumer application redirects the bank customer to authenticate and approve/deny application-provided consents.

--- a/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-accounts-flow.md
+++ b/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-accounts-flow.md
@@ -117,6 +117,36 @@ The response contains a Consent ID. A sample response looks as follows:
 }
 ```
 
+#### With JWE Payload Processing Policy
+
+If you have enabled the [JWE Payload Processing Policy](../../learn/jwe-payload-processing-policy.md), the request payload must be encrypted as a JWE (JSON Web Encryption) compact serialization using the server's public key. You must also add the following custom message builder and formatter configurations to the `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder:
+
+``` toml
+[[custom_message_builders]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextBuilder"
+
+[[custom_message_formatters]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextFormatter"
+```
+
+After adding the above configuration, restart the API Manager server.
+
+The consent initiation request with JWE encryption looks as follows:
+
+```
+curl --location --request POST 'https://localhost:8243/open-banking/v3.1/aisp/account-access-consents' \
+--header 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+--header 'x-fapi-financial-id: open-bank' \
+--header 'Content-Type: application/jose+jwe' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<JWE_ENCRYPTED_PAYLOAD>'
+```
+
+- `Content-Type`: Must be set to `application/jose+jwe` to trigger the JWE decryption mediator.
+- `<JWE_ENCRYPTED_PAYLOAD>`: The request body encrypted as a JWE compact serialization (5 base64url-encoded parts separated by dots). Encrypt the JSON payload using the server's public certificate (e.g., `wso2carbon` alias from the server keystore) with the algorithm and encryption method configured in the policy (e.g., `RSA-OAEP-256` and `A256GCM`).
+
 ### Step 3: Authorizing a consent
 
 The API consumer application redirects the bank customer to authenticate and approve/deny application-provided consents.

--- a/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow-dcr.md
+++ b/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow-dcr.md
@@ -170,6 +170,37 @@ curl --location --request POST 'https://localhost:8243/open-banking/v3.1/pisp/pa
 
 - `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
 
+#### With JWE Payload Processing Policy
+
+If you have enabled the [JWE Payload Processing Policy](../../learn/jwe-payload-processing-policy.md), the request payload must be encrypted as a JWE (JSON Web Encryption) compact serialization using the server's public key. You must also add the following custom message builder and formatter configurations to the `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder:
+
+``` toml
+[[custom_message_builders]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextBuilder"
+
+[[custom_message_formatters]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextFormatter"
+```
+
+After adding the above configuration, restart the API Manager server.
+
+The consent initiation request with JWE encryption looks as follows:
+
+```
+curl --location --request POST 'https://localhost:8243/open-banking/v3.1/pisp/payment-consents' \
+--header 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+--header 'x-fapi-financial-id: open-bank' \
+--header 'Content-Type: application/jose+jwe' \
+--header 'x-idempotency-key: 709909' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<JWE_ENCRYPTED_PAYLOAD>'
+```
+
+- `Content-Type`: Must be set to `application/jose+jwe` to trigger the JWE decryption mediator.
+- `<JWE_ENCRYPTED_PAYLOAD>`: The request body encrypted as a JWE compact serialization (5 base64url-encoded parts separated by dots). Encrypt the JSON payload using the server's public certificate (e.g., `wso2carbon` alias from the server keystore) with the algorithm and encryption method configured in the policy (e.g., `RSA-OAEP-256` and `A256GCM`).
+
 ### Step 3: Authorizing a consent
 
 The API consumer application redirects the bank customer to authenticate and approve/deny application-provided consents.
@@ -398,3 +429,22 @@ https://localhost:8243/open-banking/v3.1/pisp/payments \
 ```
 
 - `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
+
+#### With JWE Payload Processing Policy
+
+Just like Step 2, if you have enabled the [JWE Payload Processing Policy](../../learn/jwe-payload-processing-policy.md), this request payload must be encrypted as a JWE compact serialization.
+
+```
+curl -X POST \
+https://localhost:8243/open-banking/v3.1/pisp/payments \
+-H 'x-fapi-financial-id: open-bank' \
+-H 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/jose+jwe' \
+-H 'x-idempotency-key: 249667' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<JWE_ENCRYPTED_PAYLOAD>'
+```
+
+- `Content-Type`: Must be set to `application/jose+jwe` to trigger the JWE decryption mediator.
+- `<JWE_ENCRYPTED_PAYLOAD>`: The request body encrypted as a JWE compact serialization using the server's public certificate.

--- a/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow.md
+++ b/en/docs/tryout-flows/accelerator-with-is-and-apim/try-out-payments-flow.md
@@ -171,6 +171,37 @@ curl --location --request POST 'https://localhost:8243/open-banking/v3.1/pisp/pa
 
 - `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
 
+#### With JWE Payload Processing Policy
+
+If you have enabled the [JWE Payload Processing Policy](../../learn/jwe-payload-processing-policy.md), the request payload must be encrypted as a JWE (JSON Web Encryption) compact serialization using the server's public key. You must also add the following custom message builder and formatter configurations to the `deployment.toml` file inside the `<APIM_HOME>/repository/conf` folder:
+
+``` toml
+[[custom_message_builders]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextBuilder"
+
+[[custom_message_formatters]]
+content_type = "application/jose+jwe"
+class = "org.apache.axis2.format.PlainTextFormatter"
+```
+
+After adding the above configuration, restart the API Manager server.
+
+The consent initiation request with JWE encryption looks as follows:
+
+```
+curl --location --request POST 'https://localhost:8243/open-banking/v3.1/pisp/payment-consents' \
+--header 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+--header 'x-fapi-financial-id: open-bank' \
+--header 'Content-Type: application/jose+jwe' \
+--header 'x-idempotency-key: 709909' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<JWE_ENCRYPTED_PAYLOAD>'
+```
+
+- `Content-Type`: Must be set to `application/jose+jwe` to trigger the JWE decryption mediator.
+- `<JWE_ENCRYPTED_PAYLOAD>`: The request body encrypted as a JWE compact serialization (5 base64url-encoded parts separated by dots). Encrypt the JSON payload using the server's public certificate (e.g., `wso2carbon` alias from the server keystore) with the algorithm and encryption method configured in the policy (e.g., `RSA-OAEP-256` and `A256GCM`).
+
 ### Step 3: Authorizing a consent
 
 The API consumer application redirects the bank customer to authenticate and approve/deny application-provided consents.
@@ -401,3 +432,22 @@ https://localhost:8243/open-banking/v3.1/pisp/payments \
 ```
 
 - `x-jws-signature`: A detached JWS signature of the request body signed with your TPP private key.
+
+#### With JWE Payload Processing Policy
+
+Just like Step 2, if you have enabled the [JWE Payload Processing Policy](../../learn/jwe-payload-processing-policy.md), this request payload must be encrypted as a JWE compact serialization.
+
+```
+curl -X POST \
+https://localhost:8243/open-banking/v3.1/pisp/payments \
+-H 'x-fapi-financial-id: open-bank' \
+-H 'Authorization: Bearer <AUTH_HEADER_VALUE>' \
+-H 'Accept: application/json' \
+-H 'Content-Type: application/jose+jwe' \
+-H 'x-idempotency-key: 249667' \
+--cert <TRANSPORT_PUBLIC_KEY_FILE_PATH> --key <TRANSPORT_PRIVATE_KEY_FILE_PATH> \
+--data '<JWE_ENCRYPTED_PAYLOAD>'
+```
+
+- `Content-Type`: Must be set to `application/jose+jwe` to trigger the JWE decryption mediator.
+- `<JWE_ENCRYPTED_PAYLOAD>`: The request body encrypted as a JWE compact serialization using the server's public certificate.


### PR DESCRIPTION
Summary
- update the APIM library path in the JWE payload processing policy doc
- update the APIM library path in the UK JWS header processing policy doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Updated deployment instructions: copy extracted library JARs to the revised components lib directory.
- Added "JWE Payload Processing Policy" subsections across try-out flows describing encrypted payload usage and example requests using Content-Type: application/jose+jwe.
- Documented required configuration entries to register custom message builders/formatters for JWE content and noted that the API Manager must be restarted after changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->