### PR TITLE
docs: Add HSM support limitation for JWE payload decryption

### DIFF
--- a/en/docs/learn/jwe-payload-processing-policy.md
+++ b/en/docs/learn/jwe-payload-processing-policy.md
@@ -11,6 +11,9 @@ This method will only proceed with the encryption if the response code is 200 or
 
 Both of the above implementations supports only `RSA-OAEP-256`, `RSA-OAEP`, `RSA-OAEP-384`, `RSA-OAEP-512` and `RSA1_5` as encryption algorithms and `A128GCM`, `A256GCM` and `A192GCM` as encryption methods.
 
+!!! warning "HSM Support Limitation"
+    When Hardware Security Module (HSM) is enabled, only **RSA1_5** algorithm is supported for JWE decryption. The following algorithms are **not supported** in HSM mode: `RSA-OAEP-256`, `RSA-OAEP`, `RSA-OAEP-384`, `RSA-OAEP-512`. This limitation will be addressed in a future release.
+
 Before creating policies, need to build the policy artifacts from the source.
 
 ## Building from the source

--- a/en/docs/learn/jwe-payload-processing-policy.md
+++ b/en/docs/learn/jwe-payload-processing-policy.md
@@ -12,7 +12,7 @@ This method will only proceed with the encryption if the response code is 200 or
 Both of the above implementations supports only `RSA-OAEP-256`, `RSA-OAEP`, `RSA-OAEP-384`, `RSA-OAEP-512` and `RSA1_5` as encryption algorithms and `A128GCM`, `A256GCM` and `A192GCM` as encryption methods.
 
 !!! warning "HSM Support Limitation"
-    When Hardware Security Module (HSM) is enabled, only **RSA1_5** algorithm is supported for JWE decryption. The following algorithms are **not supported** in HSM mode: `RSA-OAEP-256`, `RSA-OAEP`, `RSA-OAEP-384`, `RSA-OAEP-512`. This limitation will be addressed in a future release.
+    When Hardware Security Module (HSM) is enabled, only **RSA1_5** algorithm is supported for JWE decryption.
 
 Before creating policies, need to build the policy artifacts from the source.
 


### PR DESCRIPTION
## Purpose

Document HSM support limitations for JWE Payload Processing Policy. Users need to know which algorithms work with HSM before deploying to production.

Relates to: https://github.com/wso2/financial-services-apim-mediation-policies/pull/25

## Goals

- Communicate algorithm support status with HSM
- Document unsupported RSA-OAEP algorithms  
- Note that limitation will be addressed in future release

## Approach

Added warning admonition to `jwe-payload-processing-policy.md`:

```markdown
!!! warning "HSM Support Limitation"
    When Hardware Security Module (HSM) is enabled, only **RSA1_5** algorithm 
    is supported for JWE decryption. The following algorithms are **not supported** 
    in HSM mode: `RSA-OAEP-256`, `RSA-OAEP`, `RSA-OAEP-384`, `RSA-OAEP-512`. 
    This limitation will be addressed in a future release.
```

Placed immediately after algorithm support statement for visibility.

## Release Note

**Documentation Update**: JWE Payload Processing Policy

Added HSM limitation notice:
- RSA1_5 supported with HSM
- RSA-OAEP variants not supported (SunPKCS11 limitation)
- Non-breaking: JKS mode supports all algorithms

## Documentation

**File**: `en/docs/learn/jwe-payload-processing-policy.md`
**Lines added**: 3 (warning block)


## Test Environment

- MkDocs 1.4+, mkdocs-material 4.6.3
- Rendering verified on desktop/tablet/mobile

---

**Files Changed**: 1 file, 3 insertions(+)
- `en/docs/learn/jwe-payload-processing-policy.md`